### PR TITLE
EDLY_1304 Updated courses, course_runs and search API to filter by organization

### DIFF
--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -1,10 +1,16 @@
 import ddt
 import mock
+import pytest
 from django.test import TestCase
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
-from course_discovery.apps.api.utils import cast2int, get_query_param
+from course_discovery.apps.api.utils import (
+    cast2int,
+    get_query_param,
+    get_queryset_filtered_on_organization
+)
+from course_discovery.apps.course_metadata.models import Course, CourseRun
 
 LOGGER_PATH = 'course_discovery.apps.api.utils.logger.exception'
 
@@ -40,3 +46,30 @@ class TestGetQueryParam:
 
     def test_without_request(self):
         assert get_query_param(None, 'q') is None
+
+
+class TestGetQuerysetFilteredOnOrganization:
+
+    @pytest.mark.django_db
+    def test_courses_runs_filter_on_edx_shortname(self):
+        edx_org_filter = 'course__authoring_organizations__key'
+        edx_org_short_name = 'edx'
+        edx_course_run_key = 'course-v1:edX+DemoX+Demo_Course'
+        expected_course_runs_queryset = CourseRun.objects.filter(course__authoring_organizations__key=edx_org_short_name)
+
+        course_runs_queryset = CourseRun.objects.filter(key=edx_course_run_key)
+        actual_course_runs_queryset = get_queryset_filtered_on_organization(course_runs_queryset, edx_org_filter, edx_org_short_name)
+
+        assert len(actual_course_runs_queryset) == len(expected_course_runs_queryset)
+
+    @pytest.mark.django_db
+    def test_course_filter_on_edx_shortname(self):
+        edx_org_filter = 'authoring_organizations__key'
+        edx_org_short_name = 'edx'
+        edx_course_key = 'course-v1:edX+DemoX+Demo_Course'
+        expected_courses_queryset = Course.objects.filter(authoring_organizations__key=edx_org_short_name)
+
+        courses_queryset = Course.objects.filter(key=edx_course_key)
+        actual_courses_queryset = get_queryset_filtered_on_organization(courses_queryset, edx_org_filter, edx_org_short_name)
+
+        assert len(actual_courses_queryset) == len(expected_courses_queryset)

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -65,3 +65,18 @@ def get_cache_key(**kwargs):
     key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
 
     return hashlib.md5(key.encode('utf-8')).hexdigest()
+
+
+def get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name):
+    """
+    Get queryset filtered on edx organization short name.
+
+    Arguments:
+        queryset (DRF queryset object): DRF Queryset object.
+        edx_org_filter (str): Filter to use in queryset.
+        edx_org_short_name (str): Edx organization short name.
+
+    Returns:
+        A DRF queryset object with organization filter applied.
+    """
+    return queryset if not edx_org_short_name else queryset.filter(**{edx_org_filter: edx_org_short_name})

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -21,9 +21,15 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
     def setUp(self):
         super(CourseRunViewSetTests, self).setUp()
         self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.edx_org_short_name = 'edx'
         self.client.force_authenticate(self.user)
         self.course_run = CourseRunFactory(course__partner=self.partner)
         self.course_run_2 = CourseRunFactory(course__partner=self.partner)
+        # Course_run of edx organization
+        self.course_run_3 = CourseRunFactory(
+            course__partner=self.partner,
+            course__authoring_organizations__key=self.edx_org_short_name
+        )
         self.refresh_index()
         self.request = APIRequestFactory().get('/')
         self.request.user = self.user
@@ -134,6 +140,24 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
             response.data['results'],
             self.serialize_course_run(CourseRun.objects.all().order_by(Lower('key')), many=True)
         )
+
+    def test_list_edx_org_short_name_filter(self):
+        """
+        Verify course runs filtering on edX organization.
+        """
+        course_run_api_url_with_org_filter = '{course_run_api_url}?org={edx_org_short_name}'.format(
+            course_run_api_url=reverse('api:v1:course_run-list'),
+            edx_org_short_name=self.edx_org_short_name
+        )
+        expected_serialized_course_runs = self.serialize_course_run(
+            CourseRun.objects.filter(course__authoring_organizations__key=self.edx_org_short_name).order_by(Lower('key')),
+            many=True
+        )
+
+        response = self.client.get(course_run_api_url_with_org_filter)
+        assert response.status_code == 200
+        course_runs_from_response = response.data['results']
+        assert course_runs_from_response == expected_serialized_course_runs
 
     def test_list_sorted_by_course_start_date(self):
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
@@ -278,6 +302,37 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
                 }
             }
         )
+
+    def test_contains_multiple_course_runs_edx_org_short_name_filter(self):
+        """
+        Verify contained course runs filtering on edX organization.
+        """
+        edx_org_course_run_key = 'course-v1:edX+DemoX+Demo_Course'
+        elastic_search_query_string_with_org_filter = urllib.parse.urlencode({
+            'query': 'id:course*',
+            'course_run_ids': '{course_run_1_key},{course_run_2_key},{course_run_3_key}'.format(
+                course_run_1_key=self.course_run_2.key,
+                course_run_2_key=self.course_run_3.key,
+                course_run_3_key=edx_org_course_run_key
+            ),
+            'org': self.edx_org_short_name
+        })
+        course_run_api_url_with_org_filter = '{course_run_api_url}?{elastic_search_query_string_with_org_filter}'.format(
+            course_run_api_url=reverse('api:v1:course_run-contains'),
+            elastic_search_query_string_with_org_filter=elastic_search_query_string_with_org_filter
+        )
+        expected_serialized_contained_course_runs = {
+            'course_runs': {
+                self.course_run_2.key: False,
+                self.course_run_3.key: False,
+                edx_org_course_run_key: False
+            }
+        }
+
+        response = self.client.get(course_run_api_url_with_org_filter)
+        assert response.status_code == 200
+        course_runs_from_response = response.data
+        assert course_runs_from_response == expected_serialized_contained_course_runs
 
     @ddt.data(
         {'params': {'course_run_ids': 'a/b/c'}},

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -43,6 +43,7 @@ class CourseRunViewSet(viewsets.ModelViewSet):
         """
         q = self.request.query_params.get('q')
         partner = self.request.site.partner
+        edx_org_short_name = self.request.query_params.get('org')
 
         if q:
             qs = SearchQuerySetWrapper(CourseRun.search(q).filter(partner=partner.short_code))
@@ -51,7 +52,7 @@ class CourseRunViewSet(viewsets.ModelViewSet):
             return qs
         else:
             queryset = super(CourseRunViewSet, self).get_queryset().filter(course__partner=partner)
-            return self.get_serializer_class().prefetch_queryset(queryset=queryset)
+            return self.get_serializer_class().prefetch_queryset(queryset=queryset, edx_org_short_name=edx_org_short_name)
 
     def get_serializer_context(self, *args, **kwargs):
         context = super().get_serializer_context(*args, **kwargs)
@@ -124,6 +125,12 @@ class CourseRunViewSet(viewsets.ModelViewSet):
               type: integer
               paramType: query
               multiple: false
+            - name: org
+              description: Filter results on edx organization's short name.
+              required: false
+              type: string
+              paramType: query
+              multiple: false
         """
         return super(CourseRunViewSet, self).list(request, *args, **kwargs)
 
@@ -163,15 +170,23 @@ class CourseRunViewSet(viewsets.ModelViewSet):
               type: string
               paramType: query
               multiple: false
+            - name: org
+              description: Filter results on edx organization's short name.
+              required: false
+              type: string
+              paramType: query
+              multiple: false
         """
         query = request.GET.get('query')
         course_run_ids = request.GET.get('course_run_ids')
         partner = self.request.site.partner
+        edx_org_short_name = request.GET.get('org')
 
         if query and course_run_ids:
             course_run_ids = course_run_ids.split(',')
-            course_runs = CourseRun.search(query).filter(partner=partner.short_code).filter(key__in=course_run_ids). \
-                values_list('key', flat=True)
+            course_runs = CourseRun.search(query).filter(partner=partner.short_code).filter(key__in=course_run_ids)
+            # update "course_runs" with edx organization filter
+            course_runs = course_runs.filter(course__authoring_organizations__key=edx_org_short_name).values_list('key', flat=True)
             contains = {course_run_id: course_run_id in course_runs for course_run_id in course_run_ids}
 
             instance = {'course_runs': contains}

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -52,6 +52,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         partner = self.request.site.partner
         q = self.request.query_params.get('q')
+        edx_org_short_name = self.request.query_params.get('org')
 
         if q:
             queryset = Course.search(q)
@@ -73,6 +74,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 
             queryset = self.get_serializer_class().prefetch_queryset(
                 queryset=self.queryset,
+                edx_org_short_name=edx_org_short_name,
                 course_runs=course_runs,
                 partner=partner
             )
@@ -138,6 +140,12 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
               mulitple: false
             - name: q
               description: Elasticsearch querystring query. This filter takes precedence over other filters.
+              required: false
+              type: string
+              paramType: query
+              multiple: false
+            - name: org
+              description: Filter results on edx organization's short name.
               required: false
               type: string
               paramType: query

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,11 +10,10 @@ isort==4.2.5
 lxml==3.6.1
 mock==2.0.0
 pep8==1.7.0
-pytest==3.1.0
+pytest==4.0.0
 pytest-cov==2.5.1
-# See https://github.com/pytest-dev/pytest-django/issues/473
-git+https://github.com/pytest-dev/pytest-django@de31fab4122cfc53e7116b499235b610366d941a#egg=pytest-django==3.1.3.dev47+gde31fab
-pytest-django-ordering==1.0.1
+pytest-django==3.9.0
+pytest-django-ordering==1.2.0
 pytest-responses==0.3.0
 pytest-xdist==1.22.5
 responses==0.7.0


### PR DESCRIPTION
**Description:** Updated courses, course_runs and search API to filter by the organization. 

Updated **pytest** version from `3.1.0` to `4.0.0` to run tests because `iter_markers` was deprecated in `4.0.0` although we were using right function in our dependent library `get_closet_marker` but we were still using old version`3.1.0`.
https://docs.pytest.org/en/latest/deprecations.html

Updated **pytest-django** from `3.1.3 dev commit` to `3.9.0` which fixes the pytest crashing due to pytest.fail being used from within the DB blocker.
https://pytest-django.readthedocs.io/en/latest/changelog.html#v3-8-0-2020-01-14

Updated **pytest-django-ordering** from `1.0.1` to `1.2.0` which fixes the assertion error triggered by the `get_marker_transaction` function which uses deprecated `iter_marker`.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1304

**Testing:**
Tested on the following endpoints:
1. http://edx.devstack.lms:18381/api/v1/course_runs/?org=edly
2. http://edx.devstack.lms:18381/api/v1/course_runs/contains/?org=edly
3. http://edx.devstack.lms:18381/api/v1/course_runs/course-v1:edly+DE-101+2020_T1/
4. http://edx.devstack.lms:18381/api/v1/courses/?org=edly
5. http://edx.devstack.lms:18381/api/v1/courses/edly+DE-101/
6. http://edx.devstack.lms:18381/api/v1/search/courses/?org=edly
7. http://edx.devstack.lms:18381/api/v1/search/courses/details/?org=edly
8. http://edx.devstack.lms:18381/api/v1/search/course_runs/facets/?org=edly
9. http://edx.devstack.lms:18381/api/v1/search/all/?org=edly
10.  http://edx.devstack.lms:18381/api/v1/search/all/details/?org=edly
11. http://edx.devstack.lms:18381/api/v1/search/all/facets/?org=edly

**Steps to run tests:**
1. Run tests for courses with the command below:
```
pytest course_discovery/apps/api/v1/tests/test_views/test_courses.py::CourseViewSetTests::test_edx_org_short_name_filter --ds=course_discovery.settings.test_local --reuse-db
```
2. Run tests for course_runs with the commands below:
```
pytest course_discovery/apps/api/v1/tests/test_views/test_course_runs.py::CourseRunViewSetTests::test_list_edx_org_short_name_filter --ds=course_discovery.settings.test_local --reuse-db
```
```
pytest course_discovery/apps/api/v1/tests/test_views/test_course_runs.py::CourseRunViewSetTests::test_contains_multiple_course_runs_edx_org_short_name_filter --ds=course_discovery.settings.test_local --reuse-db
```
2. Run tests for serialzier with the commands below:
```
pytest course_discovery/apps/api/tests/test_serializers.py::CourseWithProgramsSerializerTests::test_filter_courses_on_edx_org_short_name --ds=course_discovery.settings.test_local --reuse-db
```
```
pytest course_discovery/apps/api/tests/test_serializers.py::CourseRunWithProgramsSerializerTests::test_filter_course_runs_on_edx_org_short_name --ds=course_discovery.settings.test_local --reuse-db
```
3. Run tests for utils with the commands below:
```
pytest course_discovery/apps/api/tests/test_utils.py::TestGetQuerysetFilteredOnOrganization::test_courses_filter_on_edx_shortname --ds=course_discovery.settings.test_local --reuse-db -vv

```

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
