### PR TITLE
EDLY_1616 Filter programs on edx org

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -943,9 +943,11 @@ class MinimalProgramSerializer(serializers.ModelSerializer):
     degree = DegreeSerializer()
 
     @classmethod
-    def prefetch_queryset(cls, partner, queryset=None):
+    def prefetch_queryset(cls, partner, queryset=None, edx_org_short_name=None):
         # Explicitly check if the queryset is None before selecting related
+        edx_org_filter = 'authoring_organizations__key'
         queryset = queryset if queryset is not None else Program.objects.filter(partner=partner)
+        queryset = get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name)
 
         return queryset.select_related('type', 'partner').prefetch_related(
             'excluded_course_runs',
@@ -1074,7 +1076,7 @@ class ProgramSerializer(MinimalProgramSerializer):
     topics = serializers.SerializerMethodField()
 
     @classmethod
-    def prefetch_queryset(cls, partner, queryset=None):
+    def prefetch_queryset(cls, partner, queryset=None, edx_org_short_name=None):
         """
         Prefetch the related objects that will be serialized with a `Program`.
 
@@ -1082,7 +1084,9 @@ class ProgramSerializer(MinimalProgramSerializer):
         chain of related fields from programs to course runs (i.e., we want control over
         the querysets that we're prefetching).
         """
+        edx_org_filter = 'authoring_organizations__key'
         queryset = queryset if queryset is not None else Program.objects.filter(partner=partner)
+        queryset = get_queryset_filtered_on_organization(queryset, edx_org_filter, edx_org_short_name)
 
         return queryset.select_related('type', 'video', 'partner').prefetch_related(
             'excluded_course_runs',

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -734,6 +734,16 @@ class MinimalProgramSerializerTests(TestCase):
         expected = self.get_expected_data(program, request)
         self.assertDictEqual(serializer.data, expected)
 
+    def test_filter_programs_on_edx_org_short_name(self):
+        """
+        Verify programs filtering on edX organization works as expected.
+        """
+        edx_org_short_name = 'edx'
+        request = make_request()
+        edx_org_program = ProgramFactory(authoring_organizations__key=edx_org_short_name)
+        serializer = self.serializer_class(edx_org_program, context={'request': request})
+        assert serializer.data['title'] == self.get_expected_data(edx_org_program, request)['title']
+
 
 class ProgramSerializerTests(MinimalProgramSerializerTests):
     serializer_class = ProgramSerializer
@@ -1026,6 +1036,16 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
             'title_background_image': degree.title_background_image,
         }
         self.assertDictEqual(serializer.data, expected)
+
+    def test_filter_programs_on_edx_org_short_name(self):
+        """
+        Verify programs filtering on edX organization works as expected.
+        """
+        edx_org_short_name = 'edx'
+        request = make_request()
+        edx_org_program = ProgramFactory(authoring_organizations__key=edx_org_short_name)
+        serializer = self.serializer_class(edx_org_program, context={'request': request})
+        assert serializer.data['title'] == self.get_expected_data(edx_org_program, request)['title']
 
 
 class PathwaySerialzerTests(TestCase):

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -149,6 +149,25 @@ class TestProgramViewSet(SerializationMixin):
 
         self.assert_list_results(self.list_path, expected, 28)
 
+    def test_edx_org_short_name_filter(self):
+        """
+        Verify programs filtering on edX organization.
+        """
+        edx_org_short_name = 'edx'
+        programs_api_url_with_org_filter = '{programs_api_url}?org={edx_org_short_name}'.format(
+            programs_api_url=self.list_path,
+            edx_org_short_name=edx_org_short_name
+        )
+        expected_serialized_programs = self.serialize_program(
+            Program.objects.filter(authoring_organizations__key=edx_org_short_name),
+            many=True
+        )
+
+        response = self.client.get(programs_api_url_with_org_filter)
+        assert response.status_code == 200
+        programs_from_response = response.data['results']
+        assert programs_from_response == expected_serialized_programs
+
     def test_uuids_only(self):
         """
         Verify that the list view returns a simply list of UUIDs when the

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -33,12 +33,13 @@ class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
         # which happens when the queryset is stored in a class property.
         partner = self.request.site.partner
         q = self.request.query_params.get('q')
+        edx_org_short_name = self.request.query_params.get('org')
         queryset = None
 
         if q:
             queryset = Program.search(q)
 
-        return self.get_serializer_class().prefetch_queryset(queryset=queryset, partner=partner)
+        return self.get_serializer_class().prefetch_queryset(queryset=queryset, partner=partner, edx_org_short_name=edx_org_short_name)
 
     def get_serializer_context(self, *args, **kwargs):
         context = super().get_serializer_context(*args, **kwargs)
@@ -93,6 +94,12 @@ class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
               multiple: false
             - name: q
               description: Elasticsearch querystring query. This filter takes precedence over other filters
+              required: false
+              type: string
+              paramType: query
+              multiple: false
+            - name: org
+              description: Filter results on edx organization's short name.
               required: false
               type: string
               paramType: query


### PR DESCRIPTION
**Description**: Updated programs API to filter by the organization.

**JIRA**:https://edlyio.atlassian.net/browse/EDLY-1616

**Related old PR for filtering courses based on edx organization `short_name`:** https://github.com/edly-io/course-discovery/pull/4

**Testing:**

1. GET /api/v1/search/programs/?authoring_organizations=edx
2. GET /api/v1/search/programs/details/?authoring_organizations=edx
3. GET /api/v1/search/programs/facets/?authoring_organizations=edx
**These above listed endpoints runs on elastic search ideally these are not of our use**
4. GET /api/v1/programs/?org=edX
5. GET /api/v1/programs/ab40ce14-dfd2-4449-9a77-e6caad867701/
**These API endpoints are for our use**

**Steps to run tests:**
1. Run tests for programs with the command below:
```
pytest course_discovery/apps/api/v1/tests/test_views/test_programs.py::TestProgramViewSet::test_edx_org_short_name_filter --ds=course_discovery.settings.test_local --reuse-db
```
2. Run tests for programs serializer with the commands below:
```
pytest course_discovery/apps/api/tests/test_serializers.py::ProgramSerializerTests::test_filter_programs_on_edx_org_short_name --ds=course_discovery.settings.test_local --reuse-db
```
```
pytest course_discovery/apps/api/tests/test_serializers.py::MinimalProgramSerializerTests::test_filter_programs_on_edx_org_short_name --ds=course_discovery.settings.test_local --reuse-db
```

**Screenshots**
<img width="1273" alt="Screenshot 2020-07-07 at 10 40 02 AM" src="https://user-images.githubusercontent.com/15142776/86749834-fa765180-c056-11ea-937c-f0a69da5fb6e.png">
<img width="1273" alt="Screenshot 2020-07-07 at 10 40 14 AM" src="https://user-images.githubusercontent.com/15142776/86749876-019d5f80-c057-11ea-91af-6495637649ad.png">
<img width="1273" alt="Screenshot 2020-07-07 at 1 16 51 PM" src="https://user-images.githubusercontent.com/15142776/86749886-03672300-c057-11ea-8f1a-446dd88163bc.png">
<img width="1273" alt="Screenshot 2020-07-07 at 1 17 25 PM" src="https://user-images.githubusercontent.com/15142776/86749895-04985000-c057-11ea-825d-9d70283d7bb4.png">
<img width="1273" alt="Screenshot 2020-07-07 at 1 18 06 PM" src="https://user-images.githubusercontent.com/15142776/86749901-05c97d00-c057-11ea-97dd-0f43bac443e2.png">
<img width="1273" alt="Screenshot 2020-07-07 at 1 19 32 PM" src="https://user-images.githubusercontent.com/15142776/86749907-06faaa00-c057-11ea-96f6-76722ffc182e.png">
