### PR TITLE
Add edly_enable_marketing_site waffle flag to fix course publication

### DIFF
--- a/course_discovery/apps/publisher/constants.py
+++ b/course_discovery/apps/publisher/constants.py
@@ -18,3 +18,6 @@ PARTNER_COORDINATOR_GROUP_NAME = 'Partner Coordinators'
 # Waffle switches
 PUBLISHER_CREATE_AUDIT_SEATS_FOR_VERIFIED_COURSE_RUNS = 'publisher_create_audit_seats_for_verified_course_runs'
 PUBLISHER_ENABLE_READ_ONLY_FIELDS = 'publisher_enable_read_only_fields'
+
+# Edly waffle switches
+ENABLE_EDLY_MARKETING_SITE_SWITCH = 'enable_edly_marketing_site'


### PR DESCRIPTION
Description: When we try to pull courses to course-discovery site and when the partner has a marketing site it expects a marketing site to control the marketing attributes of a course so it doesn't add start date and doesn't publish a course in course-discovery. 
We added edly_enable_marketing_site waffle flag to bypass the check which checks for the marketing site.

Jira: https://edlyio.atlassian.net/browse/EDLY-1795

