### PR TITLE
Fix: Marketing URL not show

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1474,12 +1474,7 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
 
     @property
     def marketing_url(self):
-        # If the type isn't marketable, don't expose a marketing URL at all, to avoid confusion.
-        # This is very similar to self.could_be_marketable, but we don't use that because we
-        # still want draft runs to expose a marketing URL.
-        type_is_marketable = self.type.is_marketable
-
-        if self.slug and type_is_marketable:
+        if self.slug:
             path = 'course/{slug}'.format(slug=self.slug)
             return urljoin(self.course.partner.marketing_site_url_root, path)
 


### PR DESCRIPTION
**Description**

By default, `Course Run Type` is set to `Empty` https://github.com/edly-io/course-discovery/blob/burhan/EDLY-2955/course_discovery/apps/course_metadata/data_loaders/api.py#L160  and Empty course type is not marketable.

For the `marketing_url` course run a check if the type is not marketable then simple return `null` https://github.com/edly-io/course-discovery/blob/develop-juniper/course_discovery/apps/course_metadata/models.py#L1482 As we need marketing_url in every case, we should remove the check to check either type is marketable or not. 

Jira Ticket:
https://edlyio.atlassian.net/browse/EDLY-2955