### PR TITLE
EDLY-2824 Add HaystackFilter in CourseRunSearchViewSet to enable searching.

### DIFF
--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -146,7 +146,7 @@ class CourseSearchViewSet(BaseHaystackViewSet):
 
 class CourseRunSearchViewSet(BaseHaystackViewSet):
     ordering_fields = ('start', 'id', 'title')
-    filter_backends = [OrderingFilter]
+    filter_backends = [filters.HaystackFilter, OrderingFilter]
     index_models = (CourseRun,)
     detail_serializer_class = serializers.CourseRunSearchModelSerializer
     facet_serializer_class = serializers.CourseRunFacetSerializer


### PR DESCRIPTION
**Description:** Added `HaystackFilter` in `filter_backends` for `CourseRunSearchViewSet` to enable searching.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-2824

**Sample Url:**
```
http://edx.devstack.lms:18381/api/v1/search/course_runs/search/course_runs/?status=published&subject_uuids=some_uuids&q__contains=sometext&page_size=12&page=1
```

**Related PR:** https://github.com/edly-io/course-discovery/pull/19