### PR TITLE
Removes session auth class from site creation API

### DIFF
--- a/course_discovery/apps/edly_discovery_app/api/v1/tests/test_views.py
+++ b/course_discovery/apps/edly_discovery_app/api/v1/tests/test_views.py
@@ -67,7 +67,7 @@ class EdlySiteViewSet(TestCase):
         """
         self.client.logout()
         response = self.client.post(self.url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        self.assertEqual(response.status_code, 401)
 
     def test_without_permission(self):
         """

--- a/course_discovery/apps/edly_discovery_app/api/v1/views.py
+++ b/course_discovery/apps/edly_discovery_app/api/v1/views.py
@@ -18,7 +18,6 @@ class EdlySiteViewSet(APIView):
     """
     Create Default Site and Partner Configuration.
     """
-    authentication_classes = (SessionAuthentication,)
     permission_classes = [IsAuthenticated, CanAccessSiteCreation]
 
     def post(self, request):


### PR DESCRIPTION
**Description:** This PR removes the explicit declaration of SessionAuthentication as authentication class as the default authentication classes are enough. Also, the method of authentication being used from the panel backend does not work with session auth.

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.