### PR TITLE
Revert default type change and remove type__is_marketable filter from the search index

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -1020,13 +1020,6 @@ class WordPressApiDataLoader(AbstractDataLoader):
         """
         return CourseRunStatus.Published if status == 'publish' else CourseRunStatus.Unpublished
 
-    def _process_course_run_type(self, course_run):
-        """
-        Helper function that process course run status.
-        """
-        audit_course_run_type = CourseRunType.objects.get(slug=CourseRunType.AUDIT)
-        return audit_course_run_type if course_run.type.slug == CourseRunType.EMPTY else course_run.type
-
     def _process_response(self, response):
         """
         Process the response from the WordPress.
@@ -1048,7 +1041,6 @@ class WordPressApiDataLoader(AbstractDataLoader):
                 course_run.marketing_price_value = body['price_value']
                 course_run.is_marketing_price_hidden = body['hide_price']
                 course_run.status = self._process_course_status(body['status'])
-                course_run.type = self._process_course_run_type(course_run)
 
                 course_run.tags.clear()
                 for tag in body['tags']:

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -260,7 +260,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
         )
 
     def index_queryset(self, using=None):
-        return filter_visible_runs(super().index_queryset(using=using))
+        return super().index_queryset(using=using)
 
     def prepare_aggregation_key(self, obj):
         # Aggregate CourseRuns by Course key since that is how we plan to dedup CourseRuns on the marketing site.


### PR DESCRIPTION
This PR removes the default type change https://github.com/edly-io/course-discovery/pull/26 and remove the type__is_marketable filter from the search index