### PR TITLE
Introduce title_override in CourseRunSearch

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2204,6 +2204,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
             'transcript_languages',
             'type',
             'weeks_to_complete',
+            'title_override',
             'featured',
             'is_marketing_price_set',
             'marketing_price_value',

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -145,7 +145,7 @@ class CourseSearchViewSet(BaseHaystackViewSet):
 
 
 class CourseRunSearchViewSet(BaseHaystackViewSet):
-    ordering_fields = ('start', 'id', 'title')
+    ordering_fields = ('start', 'id', 'title_override')
     filter_backends = [filters.HaystackFilter, OrderingFilter]
     index_models = (CourseRun,)
     detail_serializer_class = serializers.CourseRunSearchModelSerializer

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -244,6 +244,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     license = indexes.MultiValueField(model_attr='license', faceted=True)
     has_enrollable_seats = indexes.BooleanField(model_attr='has_enrollable_seats', null=False)
     is_current_and_still_upgradeable = indexes.BooleanField(null=False)
+    title_override = indexes.CharField(model_attr='title_override', indexed=False, stored=True)
     featured = indexes.BooleanField(model_attr='featured', null=True)
     is_marketing_price_set = indexes.BooleanField(model_attr='is_marketing_price_set', null=True)
     marketing_price_value = indexes.CharField(model_attr='marketing_price_value', null=True)


### PR DESCRIPTION
This PR introduces title_override field in CourseRunSearch to support search.

Here are details why we needed this: https://github.com/django-haystack/django-haystack/issues/569#issuecomment-7371509