### PR TITLE
Filter Subjects base on Partner

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -250,20 +250,23 @@ class FAQSerializer(BaseModelSerializer):
 
 class SubjectSerializer(DynamicFieldsMixin, BaseModelSerializer):
     """Serializer for the ``Subject`` model."""
+    number_of_courses = serializers.SerializerMethodField()
 
     @classmethod
-    def prefetch_queryset(cls):
-        return Subject.objects.all().prefetch_related('translations')
+    def prefetch_queryset(cls, partner):
+        return Subject.objects.filter(partner=partner).prefetch_related('translations')
 
     class Meta:
         model = Subject
-        fields = ('name', 'subtitle', 'description', 'banner_image_url', 'card_image_url', 'slug', 'uuid', 'marketing_url')
+        fields = ('name', 'subtitle', 'description', 'banner_image_url', 'card_image_url', 'slug', 'uuid', 'marketing_url', 'number_of_courses')
 
     @property
     def choices(self):
         # choices shows the possible values via HTTP's OPTIONS verb
         return OrderedDict(sorted([(x.slug, x.name) for x in Subject.objects.all()], key=lambda x: x[1]))
 
+    def get_number_of_courses(self, obj):
+        return obj.course_set.count()
 
 class PrerequisiteSerializer(NamedModelSerializer):
     """Serializer for the ``Prerequisite`` model."""

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1492,6 +1492,8 @@ class SubjectSerializerTests(TestCase):
             'subtitle': subject.subtitle,
             'slug': subject.slug,
             'uuid': str(subject.uuid),
+            'marketing_url': None,
+            'number_of_courses': 0
         }
 
         self.assertDictEqual(serializer.data, expected)

--- a/course_discovery/apps/api/v1/views/subjects.py
+++ b/course_discovery/apps/api/v1/views/subjects.py
@@ -22,7 +22,8 @@ class SubjectViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ProxiedPagination
 
     def get_queryset(self):
-        return serializers.SubjectSerializer.prefetch_queryset()
+        partner = self.request.site.partner
+        return serializers.SubjectSerializer.prefetch_queryset(partner=partner)
 
     def list(self, request, *args, **kwargs):
         """ Retrieve a list of all subjects. """


### PR DESCRIPTION
**Description:** 
This PR filter the `Subjects` data base on the `partner` and also adds `number_of_courses` in the API response. 

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-2981