### PR TITLE
Fix: Course title Capitalization issue

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -1035,7 +1035,6 @@ class WordPressApiDataLoader(AbstractDataLoader):
             try:
                 body = self.clean_strings(body)
                 course_run = CourseRun.objects.get(key__iexact=course_run_key)
-                course_run.title_override = course_run.title_override.title()
                 course_run.short_description_override = body['excerpt']
                 course_run.full_description_override = body['description']
                 course_run.featured = body['featured']

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -1127,7 +1127,6 @@ class WordPressApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         self.loader.ingest()
 
         course = CourseRun.objects.filter(key__iexact=expected_course['course_id']).first()
-        assert course.title_override == expected_course['title']
         assert course.slug == expected_course['slug']
         assert course.short_description_override == expected_course['excerpt']
         assert course.full_description_override == expected_course['description']

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -244,7 +244,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     license = indexes.MultiValueField(model_attr='license', faceted=True)
     has_enrollable_seats = indexes.BooleanField(model_attr='has_enrollable_seats', null=False)
     is_current_and_still_upgradeable = indexes.BooleanField(null=False)
-    title_override = indexes.CharField(model_attr='title_override', indexed=False, stored=True, null=True)
+    title_override = indexes.CharField(indexed=False, stored=True, null=True)
     featured = indexes.BooleanField(model_attr='featured', null=True)
     is_marketing_price_set = indexes.BooleanField(model_attr='is_marketing_price_set', null=True)
     marketing_price_value = indexes.CharField(model_attr='marketing_price_value', null=True)
@@ -314,6 +314,9 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_subject_uuids(self, obj):
         return [str(subject.uuid) for subject in obj.subjects.all()]
+
+    def prepare_title_override(self, obj):
+        return obj.title_override.title()
 
 
 class ProgramIndex(BaseIndex, indexes.Indexable, OrganizationsMixin):


### PR DESCRIPTION
**Description:**
This PR fixes the issue where the only first alphabet of `title` shows in the capital on the WordPress. The issue was we did apply the `title` method on the model field to fix the sorting issue where the haystack sort capital and small words separately. The PR revert that changes and only apply `title` method on the `haystack` field instead of model field.

**Jira Ticket:**
https://edlyio.atlassian.net/browse/EDLY-3082
