### PR TITLE
EDLY-3243 Added ability to unlink course instructors

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -957,6 +957,7 @@ class WordPressApiDataLoader(AbstractDataLoader):
         """
         Create and add instructors to a course run.
         """
+        course_run.staff.clear()
         for course_instructor in course_instructors:
             course_instructor['partner'] = course_run.course.partner
             instructor_socials = course_instructor.pop('instructor_socials')


### PR DESCRIPTION
**Description:** This PR adds the ability to unlink course instructors. Clear will only disassociate the objects, it won't delete them.
https://docs.djangoproject.com/en/3.2/ref/models/relations/#django.db.models.fields.related.RelatedManager.clear

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-3243