### PR TITLE
Run dataloader in edly_site without celery - EDLY-5759

### DIFF
--- a/course_discovery/apps/edly_discovery_app/api/v1/views/edly_sites.py
+++ b/course_discovery/apps/edly_discovery_app/api/v1/views/edly_sites.py
@@ -34,7 +34,7 @@ class EdlySiteViewSet(APIView):
       
         try:
             self.discovery_site_setup()
-            run_dataloader.delay(partner, DEFAULT_COURSE_ID.format(partner), 'lms')
+            run_dataloader(partner, DEFAULT_COURSE_ID.format(partner), 'lms')
             return Response(
                 {'success': ERROR_MESSAGES.get('CLIENT_SITES_SETUP_SUCCESS')},
                 status=status.HTTP_200_OK


### PR DESCRIPTION
**Description:** This PR removes celery when running dataloader in `edly_sites` api.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-5759