### PR TITLE
Fix course invite flag issue - EDLY-6132

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -258,7 +258,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
             'hidden': body.get('hidden', False),
             'license': body.get('license') or '',  # license cannot be None
             'title_override': body['name'],  # we support Studio edits, even though Publisher also owns titles
-            'pacing_type': self.get_pacing_type(body)
+            'pacing_type': self.get_pacing_type(body),
+            'invite_only': body.get('invitation_only', False),
         }
 
         if not self.partner.uses_publisher:


### PR DESCRIPTION
**Description:** This PR fixes the invite only flag not being updated in course api dataloader. 

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-6132