### PR TITLE
Added currency field to course run search api

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2207,6 +2207,7 @@ class CourseFacetSerializer(BaseHaystackFacetSerializer):
 class CourseRunSearchSerializer(HaystackSerializer):
     availability = serializers.SerializerMethodField()
     first_enrollable_paid_seat_price = serializers.SerializerMethodField()
+    first_enrollable_paid_seat_currency = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
     is_enrollable = serializers.SerializerMethodField()
 
@@ -2215,6 +2216,9 @@ class CourseRunSearchSerializer(HaystackSerializer):
 
     def get_first_enrollable_paid_seat_price(self, result):
         return result.object.first_enrollable_paid_seat_price
+
+    def get_first_enrollable_paid_seat_currency(self, result):
+        return result.object.first_enrollable_paid_seat_currency
 
     def get_type(self, result):
         return result.object.type_legacy
@@ -2234,6 +2238,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
             'enrollment_start',
             'first_enrollable_paid_seat_sku',
             'first_enrollable_paid_seat_price',
+            'first_enrollable_paid_seat_currency',
             'full_description',
             'go_live_date',
             'has_enrollable_seats',

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1421,6 +1421,17 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
 
         price = int(seats[0].price) if seats[0].price else None
         return price
+    
+    @property
+    def first_enrollable_paid_seat_currency(self):
+        """
+        Returns currency code for first enrollable paid seat.
+        """
+        seats = sorted(self._enrollable_paid_seats(), key=self._upgrade_deadline_sort)
+        if not seats:
+            return None
+
+        return seats[0].currency.code or None
 
     def first_enrollable_paid_seat_sku(self):
         # Sort in python to avoid an additional request to the database for order_by

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -240,6 +240,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     has_enrollable_paid_seats = indexes.BooleanField(null=False)
     first_enrollable_paid_seat_sku = indexes.CharField(null=True)
     first_enrollable_paid_seat_price = indexes.IntegerField(null=True)
+    first_enrollable_paid_seat_currency = indexes.CharField(null=True)
     paid_seat_enrollment_end = indexes.DateTimeField(null=True)
     license = indexes.MultiValueField(model_attr='license', faceted=True)
     has_enrollable_seats = indexes.BooleanField(model_attr='has_enrollable_seats', null=False)
@@ -287,6 +288,9 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_first_enrollable_paid_seat_price(self, obj):
         return obj.first_enrollable_paid_seat_price
+
+    def prepare_first_enrollable_paid_seat_currency(self, obj):
+        return obj.first_enrollable_paid_seat_currency
 
     def prepare_is_current_and_still_upgradeable(self, obj):
         return obj.is_current_and_still_upgradeable()


### PR DESCRIPTION
This PR adds the currency code field for `first_enrollable_paid_seat_price` which is fetched from e-commerce for a paid verified course.

JIRA: https://edlyio.atlassian.net/browse/EDLY-6981