### PR TITLE
Added Seats Field to CourseRun Search API

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2209,6 +2209,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
     first_enrollable_paid_seat_price = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
     is_enrollable = serializers.SerializerMethodField()
+    seats = serializers.SerializerMethodField()
 
     def get_availability(self, result):
         return result.object.availability
@@ -2221,6 +2222,10 @@ class CourseRunSearchSerializer(HaystackSerializer):
 
     def get_is_enrollable(self, result):
         return result.object.is_enrollable
+    
+    def get_seats(self, result):
+        seats = result.object.seats.all()
+        return SeatSerializer(seats, many=True).data
 
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
@@ -2254,6 +2259,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
             'program_types',
             'published',
             'seat_types',
+            'seats',
             'short_description',
             'staff_uuids',
             'start',


### PR DESCRIPTION
**Description:**
This PR adds the seats object in response of Search API at `search/course_runs/`

**Test Details:**
Curl the following to get the test the response:
```bash
curl --location 'https://edlydev.discovery.multisitesdev.edly.io/api/v1/search/course_runs/' \
--header 'Authorization: JWT eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiAiZE1icHN6d2tGTVRWZHFjRnozZFJxQnR0UVFYTEI1Tkt4V0oiLCAiZXhwIjogMTcyNjE3Mjk1OCwgImlhdCI6IDE3MjYxMzY5NTgsICJpc3MiOiAiaHR0cHM6Ly9kZXYuY291cnNlcy5tdWx0aXNpdGVzZGV2LmVkbHkuaW8vb2F1dGgyIiwgInByZWZlcnJlZF91c2VybmFtZSI6ICJkaXNjb3Zlcnlfd29ya2VyIiwgInNjb3BlcyI6IFsicmVhZCIsICJ3cml0ZSIsICJlbWFpbCIsICJwcm9maWxlIl0sICJ2ZXJzaW9uIjogIjEuMi4wIiwgInN1YiI6ICIyOTdmOGQ0ZTYyOThjODU3MzM5ZmVkZGE5YWM1ZWQ0NiIsICJmaWx0ZXJzIjogW10sICJpc19yZXN0cmljdGVkIjogZmFsc2UsICJlbWFpbF92ZXJpZmllZCI6IHRydWUsICJlbWFpbCI6ICJkaXNjb3Zlcnlfd29ya2VyQGV4YW1wbGUuY29tIiwgIm5hbWUiOiAiZGlzY292ZXJ5X3dvcmtlciIsICJmYW1pbHlfbmFtZSI6ICIiLCAiZ2l2ZW5fbmFtZSI6ICIiLCAiYWRtaW5pc3RyYXRvciI6IHRydWUsICJzdXBlcnVzZXIiOiBmYWxzZX0.SW6NLFjuuYEZFrPl3ZSsQ62Wacr_s0SjpU7_whZEiUQ' \
--header 'Cookie: sessionid=1|791hlyo9ct7qy8exhzv8jwkes7yfd419|xLk7QCOajwmw|ImY0MWJjMzg3MjA0NGFkZDNjMDAyZmUzNTc1YmJiOWI3MjFjMzAwNmE4Mzk1YzA2YzQ5ZTgxMzAzYmY4YzdhMjIi:1sOAO2:mWCkWrzx0nc4Z_ORI1fFR7grhLU; AWSALB=dL4PJgH1RJaQ1psVxjBq5r369Pumb9wcITwEu1UElQro67rI+CCOYL3qUYiFAw/dx288PhGwDVnuZNgHnrODsA3eLEkozQ2+epQKBlFvADUSWGc+CeuWxVa1NaU0; AWSALBCORS=dL4PJgH1RJaQ1psVxjBq5r369Pumb9wcITwEu1UElQro67rI+CCOYL3qUYiFAw/dx288PhGwDVnuZNgHnrODsA3eLEkozQ2+epQKBlFvADUSWGc+CeuWxVa1NaU0; sessionid=1|30ge1irho31r5o9jwnu6m1j0ojd9sx8o|JJ5OuPZP4W8L|IjdlYTRhOTY3YTY4NzZmMmFiNmU4ZDhiMWI2MDA4N2NhM2Y2NTI4ZTc3NjJjNTZmNmIzNjIzMjcxYTg1YmU4ZTYi:1soh4g:5sjilgKrjAU9x3rdbG2WJTejMfw; AWSALB=HMvI0HER7S4pK8tWuRQopjJjabx6AIFDuIGuxJ8G45zQoPck9LFfjZwtcyFO7S4M0WsAJYixzWUfITFnFVCAz0m+yfJtYwWR9cARjZD8VboeJcoI4zzhMGbK/mTn; AWSALBCORS=HMvI0HER7S4pK8tWuRQopjJjabx6AIFDuIGuxJ8G45zQoPck9LFfjZwtcyFO7S4M0WsAJYixzWUfITFnFVCAz0m+yfJtYwWR9cARjZD8VboeJcoI4zzhMGbK/mTn'
```