### PR TITLE
Fix: Title override not being saved correctly

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import html
 import logging
 import math
 import threading
@@ -259,7 +260,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             'enrollment_end': self.parse_date(body['enrollment_end']),
             'hidden': body.get('hidden', False),
             'license': body.get('license') or '',  # license cannot be None
-            'title_override': body['name'],  # we support Studio edits, even though Publisher also owns titles
+            'title_override': html.unescape(body['name']),  # we support Studio edits, even though Publisher also owns titles
             'pacing_type': self.get_pacing_type(body),
             'invite_only': body.get('invitation_only', False),
         }


### PR DESCRIPTION
**Description:** This PR fixes the course title being html escaped while saving in discovery.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-7174