### PR TITLE
Fix title for course and program objects

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -280,7 +280,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
 
     def format_course_data(self, body):
         defaults = {
-            'title': body['name'],
+            'title': html.unescape(body['name']),
         }
 
         if not self.partner.uses_publisher:
@@ -851,7 +851,7 @@ class ProgramsApiDataLoader(AbstractDataLoader):
         try:
             defaults = {
                 'uuid': uuid,
-                'title': body['name'],
+                'title': html.unescape(body['name']),
                 'subtitle': body['subtitle'],
                 'type': self.XSERIES,
                 'status': body['status'],


### PR DESCRIPTION
**Description:** This PR fixes the `Course` title being html escaped.