### PR TITLE
Added filter option based on date created.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2320,6 +2320,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
             'recent_enrollment_count',
             'expected_program_type',
             'expected_program_name',
+            'created'
         )
 
 

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -146,7 +146,7 @@ class CourseSearchViewSet(BaseHaystackViewSet):
 
 
 class CourseRunSearchViewSet(BaseHaystackViewSet):
-    ordering_fields = ('start', 'id', 'title_override', 'average_rating', 'total_raters')
+    ordering_fields = ('created', 'start', 'id', 'title_override', 'average_rating', 'total_raters')
     filter_backends = [filters.HaystackFilter, OrderingFilter]
     index_models = (CourseRun,)
     detail_serializer_class = serializers.CourseRunSearchModelSerializer

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -272,7 +272,8 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     recent_enrollment_count = indexes.IntegerField(model_attr='recent_enrollment_count', null=True)  
     expected_program_type = indexes.CharField(model_attr='expected_program_type__name', null=True)  
     expected_program_name = indexes.CharField(model_attr='expected_program_name', null=True)  
-    invite_only = indexes.BooleanField(model_attr='invite_only') 
+    invite_only = indexes.BooleanField(model_attr='invite_only')
+    created = indexes.DateTimeField(model_attr='created', null=True, faceted=True)
 
     def read_queryset(self, using=None):
         # Pre-fetch all fields required by the CourseRunSearchSerializer. Unfortunately, there's


### PR DESCRIPTION
**Description:**
This PR adds the `created` in search indexes for course_runs so that most recent course filters can work.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-7172