### PR TITLE
temp: Use correct elasticsearch field name for .raw field facet filtering

### DIFF
--- a/course_discovery/apps/edx_elasticsearch_dsl_extensions/backends.py
+++ b/course_discovery/apps/edx_elasticsearch_dsl_extensions/backends.py
@@ -121,7 +121,9 @@ class FacetedFieldSearchFilterBackend(FacetedSearchFilterBackend):
             if not field_facets.get(field):
                 raise ParseError('The selected query facet [{facet}] is not valid.'.format(facet=field))
 
-            _filters.append(ESDSLQ('term', **{field: value}))
+            # Use the actual elasticsearch field name from configuration, not the facet key
+            elasticsearch_field = field_facets[field]['field']
+            _filters.append(ESDSLQ('term', **{elasticsearch_field: value}))
 
         queryset = queryset.query('bool', **{'filter': _filters})
         return queryset

--- a/course_discovery/apps/edx_elasticsearch_dsl_extensions/backends.py
+++ b/course_discovery/apps/edx_elasticsearch_dsl_extensions/backends.py
@@ -122,8 +122,7 @@ class FacetedFieldSearchFilterBackend(FacetedSearchFilterBackend):
                 raise ParseError('The selected query facet [{facet}] is not valid.'.format(facet=field))
 
             # Use the actual elasticsearch field name from configuration, not the facet key
-            elasticsearch_field = field_facets[field]['field']
-            _filters.append(ESDSLQ('term', **{elasticsearch_field: value}))
+            _filters.append(ESDSLQ('term', **{field: value}))
 
         queryset = queryset.query('bool', **{'filter': _filters})
         return queryset


### PR DESCRIPTION
When filtering by facets that use .raw fields (like language.raw), the filter_by_facets method was incorrectly using the facet configuration key instead of the actual elasticsearch field name, causing filters to fail for case-sensitive .raw fields.